### PR TITLE
Meteor 1.4.3.1 compatability

### DIFF
--- a/facebook_server.js
+++ b/facebook_server.js
@@ -38,7 +38,7 @@ var getIdentity = function (accessToken, fields) {
     return HTTP.get("https://graph.facebook.com/me", {
       params: {
         access_token: accessToken,
-        fields: fields
+        fields: fields.join(",")
       }
     }).data;
   } catch (err) {

--- a/package.js
+++ b/package.js
@@ -12,8 +12,8 @@ Package.on_use(function(api) {
   // Export Accounts (etc) to packages using this one.
   api.imply('accounts-base', ['client', 'server']);
   api.use('accounts-oauth', ['client', 'server']);
-  api.use('facebook', ['client', 'server']);
-  
+  api.use('facebook-oauth', ['client', 'server']);
+
   api.use('service-configuration', ['client', 'server']);
   api.use('http', ['server']);
   api.use('underscore', 'server');


### PR DESCRIPTION
Facebook log in stopped working in Meteor 1.4.3.1 on our app. We traced the cause back to an outdated dependency of this package and the way the fields projection string param is handled when attempted to GET the user's FB profile information.

These two little changes now allows us to use this package in our app currently running on Meteor 1.4.3.1 and have working FB login.